### PR TITLE
Add missing line continuations to footnote

### DIFF
--- a/ch1.adoc
+++ b/ch1.adoc
@@ -1,5 +1,5 @@
-:what_matters: footnote:[Obviously compilers have to follow stricter rules, but for the
-purposes of learning and actually using assembly directly, there's no reason to make your life
+:what_matters: footnote:[Obviously compilers have to follow stricter rules, but for the \
+purposes of learning and actually using assembly directly, there's no reason to make your life \
 harder than necessary.]
 
 == Chapter 1: Data


### PR DESCRIPTION
In order to break up a footnote over multiple lines, it's necessary to put ` \` at the end of each line. Without it, the formatting gets messed up, and in this case part of the footnote in Chapter 1 ends up [in the Chapter 0 exercises](https://www.robertwinkler.com/projects/mips_book/mips_book.html#_exercises) and the rest is [inline where the footnote reference is](https://www.robertwinkler.com/projects/mips_book/mips_book.html#_exercises:~:text=wayfootnote%3A%5BObviously).

I think [the Asciidoctor documentation for footnotes](https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/) is inadequate here, since it simply says that "The text may span several lines" without explaining how or including a multiline footnote in the examples. As someone who wasn't familiar with Asciidoctor, it took some effort to find [the relevant page explaining the syntax](https://docs.asciidoctor.org/asciidoc/latest/attributes/wrap-values/).